### PR TITLE
docs: present the capsule as Unicity AOS, not the runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # capsule-telegram
 
-Telegram Bot uplink capsule for [Astrid OS](https://github.com/unicity-astrid/astrid) — bridges the Telegram Bot API to the kernel IPC bus, giving your Astrid agent a Telegram chat interface.
+Telegram Bot uplink capsule for [Unicity AOS](https://github.com/unicity-aos/aos-ce) — bridges the Telegram Bot API to the kernel IPC bus, giving your Unicity AOS agent a Telegram chat interface.
 
 ## Features
 
@@ -24,27 +24,27 @@ Telegram Bot uplink capsule for [Astrid OS](https://github.com/unicity-astrid/as
 ### 2. Install the Capsule
 
 ```bash
-astrid capsule install @unicity-astrid/capsule-telegram
+aos capsule install @unicity-aos/capsule-telegram
 ```
 
 Or from a local checkout:
 
 ```bash
-astrid capsule install ~/path/to/capsule-telegram
+aos capsule install ~/path/to/capsule-telegram
 ```
 
 During installation, you'll be prompted for:
 - **Bot Token** — the token from BotFather
 - **Allowed User IDs** — comma-separated Telegram user IDs (leave empty to allow all users)
 
-Configuration is preserved across reinstalls (use `astrid capsule remove --purge` to clear it).
+Configuration is preserved across reinstalls (use `aos capsule remove --purge` to clear it).
 
 > **Tip:** To find your Telegram user ID, message [@userinfobot](https://t.me/userinfobot).
 
 ### 3. Start the Daemon and Use It
 
 ```bash
-astrid start
+aos start
 ```
 
 Open your bot in Telegram and send a message. The agent will respond in the chat.
@@ -52,7 +52,7 @@ Open your bot in Telegram and send a message. The agent will respond in the chat
 ## Architecture
 
 ```
-Telegram Bot API                Astrid Kernel IPC Bus
+Telegram Bot API                Runtime Kernel IPC Bus
   │                                │
   │  getUpdates (HTTP long poll)   │
   │◄───────────────────────────────│
@@ -107,7 +107,7 @@ All state (sessions, update offset) is persisted in the kernel KV store.
 cargo build --release
 
 # Package an installable .capsule artifact
-astrid capsule build . --output ./dist
+aos capsule build . --output ./dist
 
 # Run the unit tests on the native host target. The default target is WASM,
 # which cannot execute test binaries, so this flag is required.


### PR DESCRIPTION
Product-facing copy referred to the runtime throughout — and via a pre-rename organisation at that.

aos-ce already documents the convention this follows:

> Present product-facing capsule copy consistently as Unicity AOS while preserving stable Astrid Runtime crate, WIT, topic, artifact, and ABI names.

## Changed — product surface

| | Was | Now |
|---|---|---|
| Header | `[Astrid OS](github.com/unicity-astrid/astrid)` | `[Unicity AOS](github.com/unicity-aos/aos-ce)` |
| Install | `astrid capsule install @unicity-astrid/…` | `aos capsule install @unicity-aos/…` |
| Other commands | `astrid start`, `astrid capsule remove/build` | `aos …` |
| Diagram | `Astrid Kernel IPC Bus` | `Runtime Kernel IPC Bus` |

The header wording and the diagram label now match what aos-ce's own copy of this README already shipped, verbatim.

`capsule` and `start` are **not** AOS-owned roots — only `init`/`status`/`migrate`/`update`/`distro`/`serve-health` are — so both pass through to the bundled runtime with arguments, exit codes, and signals unchanged. `aos capsule build` is aos-ce's own worked example of that delegation.

## Unchanged — deliberately

`astrid.v1.*` topic names and the `#[astrid::run]` macro stay. Those are stable ABI identifiers a capsule author types literally; renaming them in prose would be actively wrong rather than merely cosmetic.

## Also: the install target was stale

`@unicity-astrid/capsule-telegram` → `@unicity-aos/capsule-telegram`.

The old organisation still redirects, which is exactly why this survived unnoticed — but a redirect lapses the moment someone registers the vacated name. And `@org/repo` is not a namespace lookup: the resolver interpolates the string straight into a GitHub URL, so this is a stale reference users execute.

Verified via the API that `unicity-astrid/astrid` redirects to `astrid-runtime/astrid` (not to anything under `unicity-aos`), so the two stale references needed different corrections. No `unicity-astrid` references remain anywhere in the repo.