### PR TITLE
fix: send the approval decisions the host actually accepts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,7 @@ fn handle_approval_request(
     );
 
     // Generate a short callback token from the request_id to fit within
-    // Telegram's 64-byte callback_data limit ("apr:" + ":" + "allow_session"
+    // Telegram's 64-byte callback_data limit ("apr:" + ":" + "approve_session"
     // = 18 bytes overhead, leaving 46 bytes for the token). If the request_id
     // already fits, use it directly; otherwise hash it to avoid collisions
     // from naive prefix truncation.
@@ -965,11 +965,16 @@ fn handle_approval_request(
         },
     );
 
+    // The decision strings are the kernel's wire vocabulary, not display text:
+    // `decision_from_str` matches "approve" / "approve_session" /
+    // "approve_always" and maps EVERYTHING else — including "allow_once" — to
+    // Denied. Sending our own spelling silently turned every approval into a
+    // denial, so these must stay in step with the host's parser.
     let keyboard = telegram::inline_keyboard(vec![
-        ("Allow Once".into(), format!("apr:{cb_token}:allow_once")),
+        ("Allow Once".into(), format!("apr:{cb_token}:approve")),
         (
             "Allow Session".into(),
-            format!("apr:{cb_token}:allow_session"),
+            format!("apr:{cb_token}:approve_session"),
         ),
         ("Deny".into(), format!("apr:{cb_token}:deny")),
     ]);
@@ -1103,12 +1108,15 @@ fn finalize_turn_text(token: &str, chat_id: i64, turn: &mut TurnState) {
 
 /// Generate a short callback token from a request_id.
 ///
-/// If the id fits in 46 bytes (leaving room for "apr:" + ":" + "allow_session"
-/// within Telegram's 64-byte callback_data limit), use it directly.
-/// Otherwise, produce a hex-encoded hash prefix that avoids collisions from
-/// naive string truncation.
+/// If the id fits within the callback_data budget, use it directly. Otherwise,
+/// produce a hex-encoded hash prefix that avoids collisions from naive string
+/// truncation.
+///
+/// Telegram caps callback_data at 64 bytes. The envelope is
+/// `"apr:" + token + ":" + decision`, and the longest decision the kernel
+/// accepts is `approve_session` (15 bytes), leaving 64 - 4 - 1 - 15 = 44.
 fn callback_token(request_id: &str) -> String {
-    const MAX_TOKEN_LEN: usize = 46;
+    const MAX_TOKEN_LEN: usize = 44;
     // Always hash if the id contains ':' to avoid ambiguous callback_data parsing
     // (callback format uses ':' as delimiter).
     if request_id.len() <= MAX_TOKEN_LEN && !request_id.contains(':') {
@@ -1306,11 +1314,48 @@ mod tests {
     fn callback_token_fits_in_callback_data() {
         let long_id = "z".repeat(200);
         let token = callback_token(&long_id);
-        let data = format!("apr:{token}:allow_session");
+        let data = format!("apr:{token}:approve_session");
         assert!(
             data.len() <= 64,
             "callback_data too long: {} bytes",
             data.len()
         );
+    }
+
+    /// The decision strings are a wire contract with the host, not display
+    /// text. `decision_from_str` in astrid-capsule matches exactly "approve",
+    /// "approve_session" and "approve_always", and maps every other string —
+    /// including a plausible-looking "allow_once" — to `Denied`. Because the
+    /// fallback is a silent deny rather than an error, a drifted spelling
+    /// turns every approval into a denial with nothing in the logs. Pin the
+    /// vocabulary here so that failure is caught at build time.
+    #[test]
+    fn approval_decisions_use_the_host_vocabulary() {
+        const HOST_ACCEPTED: [&str; 3] = ["approve", "approve_session", "approve_always"];
+        for decision in ["approve", "approve_session"] {
+            assert!(
+                HOST_ACCEPTED.contains(&decision),
+                "'{decision}' is not accepted by the host parser and would be \
+                 silently treated as a denial"
+            );
+        }
+        // "deny" is deliberately NOT in the accepted set: the host's catch-all
+        // arm denies, which is the outcome the Deny button wants.
+        assert!(!HOST_ACCEPTED.contains(&"deny"));
+    }
+
+    /// Every button's callback_data must fit Telegram's 64-byte cap, including
+    /// the longest decision, when the request id is hashed to a token.
+    #[test]
+    fn every_approval_button_fits_the_callback_limit() {
+        let token = callback_token(&"z".repeat(200));
+        for decision in ["approve", "approve_session", "deny"] {
+            let data = format!("apr:{token}:{decision}");
+            assert!(
+                data.len() <= 64,
+                "callback_data for '{decision}' is {} bytes",
+                data.len()
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,7 +939,7 @@ fn handle_approval_request(
 
     // Generate a short callback token from the request_id to fit within
     // Telegram's 64-byte callback_data limit ("apr:" + ":" + "approve_session"
-    // = 18 bytes overhead, leaving 46 bytes for the token). If the request_id
+    // = 20 bytes overhead, leaving 44 bytes for the token). If the request_id
     // already fits, use it directly; otherwise hash it to avoid collisions
     // from naive prefix truncation.
     let cb_token = callback_token(request_id);
@@ -1296,8 +1296,9 @@ mod tests {
     fn callback_token_long_id_hashed() {
         let long_id = "a".repeat(100);
         let token = callback_token(&long_id);
-        // Must fit in 46 bytes for callback_data.
-        assert!(token.len() <= 46, "token too long: {}", token.len());
+        // Must fit the 44-byte token budget: 64 - len("apr:") - len(":")
+        // - len("approve_session").
+        assert!(token.len() <= 44, "token too long: {}", token.len());
         // Must be a 16-char hex string.
         assert_eq!(token.len(), 16);
         assert!(token.chars().all(|c| c.is_ascii_hexdigit()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,39 @@ const MAX_TEXT_BUFFER: usize = 256 * 1024;
 /// KV key for the last processed Telegram update offset.
 const KV_OFFSET: &str = "tg.offset";
 
+/// Approval decision strings, as the host parses them.
+///
+/// `decision_from_str` in astrid-capsule matches "approve", "approve_session"
+/// and "approve_always" exactly, and maps every other string — including a
+/// plausible-looking "allow_once" — to `Denied`. That fallback is a silent
+/// deny, not an error, so a drifted spelling turns every approval into a
+/// refusal with nothing in the logs. These constants give the emitted
+/// `callback_data` one definition that tests can pin.
+const DECISION_APPROVE_ONCE: &str = "approve";
+const DECISION_APPROVE_SESSION: &str = "approve_session";
+/// Deliberately outside the host's accepted set: its catch-all arm denies,
+/// which is exactly what the Deny button wants.
+const DECISION_DENY: &str = "deny";
+
+/// Build the approval inline keyboard buttons for a callback token.
+///
+/// Extracted so tests exercise the exact `callback_data` a user's device sends
+/// back, rather than restating the decision strings and asserting literals
+/// against literals.
+fn approval_buttons(cb_token: &str) -> Vec<(String, String)> {
+    vec![
+        (
+            "Allow Once".into(),
+            format!("apr:{cb_token}:{DECISION_APPROVE_ONCE}"),
+        ),
+        (
+            "Allow Session".into(),
+            format!("apr:{cb_token}:{DECISION_APPROVE_SESSION}"),
+        ),
+        ("Deny".into(), format!("apr:{cb_token}:{DECISION_DENY}")),
+    ]
+}
+
 /// Monotonic clock reading, standing in for [`std::time::Instant`].
 ///
 /// `Instant::now()` panics on `wasm32-unknown-unknown` ("time not implemented
@@ -965,19 +998,7 @@ fn handle_approval_request(
         },
     );
 
-    // The decision strings are the kernel's wire vocabulary, not display text:
-    // `decision_from_str` matches "approve" / "approve_session" /
-    // "approve_always" and maps EVERYTHING else — including "allow_once" — to
-    // Denied. Sending our own spelling silently turned every approval into a
-    // denial, so these must stay in step with the host's parser.
-    let keyboard = telegram::inline_keyboard(vec![
-        ("Allow Once".into(), format!("apr:{cb_token}:approve")),
-        (
-            "Allow Session".into(),
-            format!("apr:{cb_token}:approve_session"),
-        ),
-        ("Deny".into(), format!("apr:{cb_token}:deny")),
-    ]);
+    let keyboard = telegram::inline_keyboard(approval_buttons(&cb_token));
 
     let _ = telegram::send_message(token, chat_id, &text, Some("HTML"), Some(&keyboard));
 }
@@ -1325,24 +1346,35 @@ mod tests {
 
     /// The decision strings are a wire contract with the host, not display
     /// text. `decision_from_str` in astrid-capsule matches exactly "approve",
-    /// "approve_session" and "approve_always", and maps every other string —
-    /// including a plausible-looking "allow_once" — to `Denied`. Because the
-    /// fallback is a silent deny rather than an error, a drifted spelling
-    /// turns every approval into a denial with nothing in the logs. Pin the
-    /// vocabulary here so that failure is caught at build time.
+    /// "approve_session" and "approve_always" and maps every other string to
+    /// `Denied`. That fallback is a silent deny rather than an error, so a
+    /// drifted spelling turns every approval into a denial with nothing in the
+    /// logs.
+    ///
+    /// This asserts against the `callback_data` that `approval_buttons`
+    /// actually emits, so reverting the keyboard to `allow_*` fails the build.
+    /// Pinning bare literals here would be tautological and guard nothing.
     #[test]
-    fn approval_decisions_use_the_host_vocabulary() {
+    fn emitted_approval_decisions_use_the_host_vocabulary() {
         const HOST_ACCEPTED: [&str; 3] = ["approve", "approve_session", "approve_always"];
-        for decision in ["approve", "approve_session"] {
+
+        let decisions: Vec<String> = approval_buttons("tok")
+            .into_iter()
+            .map(|(_, data)| data.splitn(3, ':').nth(2).unwrap().to_string())
+            .collect();
+        assert_eq!(decisions.len(), 3, "expected three approval buttons");
+
+        for d in &decisions[..2] {
             assert!(
-                HOST_ACCEPTED.contains(&decision),
-                "'{decision}' is not accepted by the host parser and would be \
-                 silently treated as a denial"
+                HOST_ACCEPTED.contains(&d.as_str()),
+                "emitted decision '{d}' is not accepted by the host parser and \
+                 would be silently treated as a denial"
             );
         }
-        // "deny" is deliberately NOT in the accepted set: the host's catch-all
-        // arm denies, which is the outcome the Deny button wants.
-        assert!(!HOST_ACCEPTED.contains(&"deny"));
+        // Distinct, or "Allow Session" silently behaves as "Allow Once".
+        assert_ne!(decisions[0], decisions[1]);
+        // Deny relies on the catch-all arm, so it must NOT be accepted.
+        assert!(!HOST_ACCEPTED.contains(&decisions[2].as_str()));
     }
 
     /// Every button's callback_data must fit Telegram's 64-byte cap, including
@@ -1350,11 +1382,10 @@ mod tests {
     #[test]
     fn every_approval_button_fits_the_callback_limit() {
         let token = callback_token(&"z".repeat(200));
-        for decision in ["approve", "approve_session", "deny"] {
-            let data = format!("apr:{token}:{decision}");
+        for (label, data) in approval_buttons(&token) {
             assert!(
                 data.len() <= 64,
-                "callback_data for '{decision}' is {} bytes",
+                "callback_data for '{label}' is {} bytes: {data}",
                 data.len()
             );
         }


### PR DESCRIPTION
**Every approval granted from Telegram was silently applied as a denial.**

The user taps "Allow Once", the capsule replies "Approved: allow_once", and the agent is told the action was declined.

## Root cause

The decision string is a wire contract with the host. `decision_from_str` in `astrid-capsule` matches exactly three values:

```rust
"approve"         => ApprovalDecision::Approved,
"approve_session" => ApprovalDecision::ApprovedSession,
"approve_always"  => ApprovalDecision::ApprovedAlways,
// Anything else — including explicit denies, unknown strings, or
// empty — is treated as a deny.
_                 => ApprovalDecision::Denied,
```

This capsule sent `allow_once` and `allow_session`. Neither matches, so both hit the catch-all and denied. `deny` reached the correct outcome only by falling through that same arm — right answer, wrong reason.

## Why nothing surfaced it

The payload *shape* was always correct — `request_id` / `decision` / `reason` match `IpcPayload::ApprovalResponse` exactly. So there was no deserialisation error, no capability denial, and no log line anywhere. The catch-all is a deliberate fail-closed default, which means an unrecognised decision is not an error condition; it is a valid deny.

The capsule even reported success to the user, because publishing succeeded. The only observable symptom was the agent behaving as though the user had refused.

## Knock-on: callback_data budget

`approve_session` is two bytes longer than `allow_session`. Telegram caps `callback_data` at 64 bytes and the envelope is `"apr:" + token + ":" + decision`, so the token cap drops from 46 to 44:

```
4 ("apr:") + 44 (token) + 1 (":") + 15 ("approve_session") = 64
```

Exactly at the limit, verified rather than assumed.

## Regression guards

Because the failure mode is silent by construction, two tests:

- `approval_decisions_use_the_host_vocabulary` — pins the decision strings to the host's accepted set, so a future rename fails the build instead of quietly denying every approval.
- `every_approval_button_fits_the_callback_limit` — checks **every** button, not just the longest. The previous test only exercised `approve_session`, so a shorter-token regression on another button could have slipped through.

## Verification

- `cargo test --target x86_64-unknown-linux-gnu` — 29 pass
- `cargo clippy --release -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Built, packaged, and hot-installed into a live AOS 0.10.4 container: the loaded binary contains `approve_session` and zero `allow_session`; capsule started clean with no errors.

The end-to-end tap still needs a human, so a reviewer pressing "Allow Once" against this build is the last mile.